### PR TITLE
Fixing range error in two_arm_pouring.py

### DIFF
--- a/dexmimicgen/environments/two_arm_pouring.py
+++ b/dexmimicgen/environments/two_arm_pouring.py
@@ -295,7 +295,7 @@ class TwoArmPouring(TwoArmDexMGEnv):
                 name="BowlSampler",
                 mujoco_objects=self.bowl,
                 x_range=(-0.15, -0.05),
-                y_range=(-0.10, -0.15),
+                y_range=(-0.15, -0.1),
                 rotation=(0.0, 0.0),
                 rotation_axis="z",
                 ensure_object_boundary_in_range=False,


### PR DESCRIPTION
Dear Authors,

Thanks for releasing the great simulation environments!
When I launched the humanoid pouring environments, I found the error below:

<details>
  <summary>Error log for TwoArmPouring</summary>

```bash
(dmg) changyeon@alin18:~/workspace/dexmimicgen$ python scripts/playback_datasets.py --dataset /home/changyeon/workspace/dexmimicgen/datasets/generated/two_arm_pouring.hdf5 --n 1
[robosuite WARNING] No private macro file found! (macros.py:57)
[robosuite WARNING] It is recommended to use a private macro file (macros.py:58)
[robosuite WARNING] To setup, run: python /home/changyeon/workspace/robosuite/robosuite/scripts/setup_macros.py (macros.py:59)
[robosuite WARNING] Could not import robosuite_models. Some robots may not be available. If you want to use these robots, please install robosuite_models from source (https://github.com/ARISE-Initiative/robosuite_models) or through pip install. (__init__.py:30)
Traceback (most recent call last):
  File "/home/changyeon/workspace/dexmimicgen/scripts/playback_datasets.py", line 552, in <module>
    playback_dataset(args)
  File "/home/changyeon/workspace/dexmimicgen/scripts/playback_datasets.py", line 376, in playback_dataset
    env = robosuite.make(**env_kwargs)
  File "/home/changyeon/workspace/robosuite/robosuite/environments/base.py", line 42, in make
    return REGISTERED_ENVS[env_name](*args, **kwargs)
  File "/home/changyeon/workspace/dexmimicgen/dexmimicgen/environments/two_arm_pouring.py", line 66, in __init__
    super().__init__(
  File "/home/changyeon/workspace/dexmimicgen/dexmimicgen/environments/two_arm_dexmg_env.py", line 20, in __init__
    super().__init__(*args, **kwargs)
  File "/home/changyeon/workspace/robosuite/robosuite/environments/manipulation/manipulation_env.py", line 172, in __init__
    super().__init__(
  File "/home/changyeon/workspace/robosuite/robosuite/environments/robot_env.py", line 221, in __init__
    super().__init__(
  File "/home/changyeon/workspace/robosuite/robosuite/environments/base.py", line 161, in __init__
    self._reset_internal()
  File "/home/changyeon/workspace/dexmimicgen/dexmimicgen/environments/two_arm_pouring.py", line 336, in _reset_internal
    object_placements = self.placement_initializer.sample()
  File "/home/changyeon/workspace/robosuite/robosuite/utils/placement_samplers.py", line 443, in sample
    new_placements = sampler.sample(fixtures=placed_objects, **s_args)
  File "/home/changyeon/workspace/robosuite/robosuite/utils/placement_samplers.py", line 276, in sample
    object_y = self._sample_y(horizontal_radius) + base_offset[1]
  File "/home/changyeon/workspace/robosuite/robosuite/utils/placement_samplers.py", line 189, in _sample_y
    return self.rng.uniform(high=maximum, low=minimum)
  File "_generator.pyx", line 949, in numpy.random._generator.Generator.uniform
  File "_common.pyx", line 616, in numpy.random._common.cont
  File "_common.pyx", line 422, in numpy.random._common.check_constraint
ValueError: high - low < 0
```
</details>

I found that the range order is wrong in the environment file, so I changed it, and it works.
Feel free to leave any questions!

Many thanks,
Changyeon